### PR TITLE
fix: replaced editor default formatter with prettier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,13 @@
       "autoFix": true
     }
   ],
-  "eslint.provideLintTask": true,
-  "typescript.format.enable": false,
-  "javascript.format.enable": false
+  "eslint.lintTask.enable": true,
+  "typescript.format.enable": true,
+  "javascript.format.enable": true,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/src/built-in-plugins/ensure-project-files/plugin/index.ts
+++ b/src/built-in-plugins/ensure-project-files/plugin/index.ts
@@ -153,8 +153,9 @@ function ensureVscode() {
   pri.project.addProjectFiles({
     fileName: path.join(pri.projectRootPath, '.vscode/settings.json'),
     pipeContent: (prev: string) => {
+      const pickedPrev = _.omit(safeJsonParse(prev), 'eslint.provideLintTask');
       return `${JSON.stringify(
-        _.merge({}, safeJsonParse(prev), {
+        _.merge({}, pickedPrev, {
           'editor.formatOnSave': true,
           'typescript.tsdk': 'node_modules/typescript/lib',
           'eslint.autoFixOnSave': true,
@@ -164,9 +165,15 @@ function ensureVscode() {
             { language: 'typescript', autoFix: true },
             { language: 'typescriptreact', autoFix: true },
           ],
-          'eslint.provideLintTask': true,
+          'eslint.lintTask.enable': true,
           'typescript.format.enable': true,
           'javascript.format.enable': true,
+          '[typescriptreact]': {
+            'editor.defaultFormatter': 'esbenp.prettier-vscode',
+          },
+          '[typescript]': {
+            'editor.defaultFormatter': 'esbenp.prettier-vscode',
+          },
         }),
         null,
         2,


### PR DESCRIPTION
修改vscode setting.json的default formatter配置，保证prettier可以正常使用