### PR TITLE
use sync mode when process.stdio is connected to pipe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pri",
-  "version": "4.0.30-beta.6",
+  "version": "4.0.30-beta.7",
   "types": "src/node/index.ts",
   "main": "built/node/index.js",
   "scripts": {

--- a/src/utils/lint.ts
+++ b/src/utils/lint.ts
@@ -29,6 +29,13 @@ class DefaultOptions {
 }
 
 export async function lint(options?: Partial<DefaultOptions>) {
+  // https://nodejs.org/api/process.html#process_a_note_on_process_i_o
+  // 通过 child_process 运行 pri，stdio 设置 pipe 模式时, 标准输出是异步的, 导致输出被截断,
+  // 此处判断在 pipe 模式设置成同步输出
+  if (!process.stdout.isTTY) {
+    (process.stdout as any)?._handle?.setBlocking(true);
+    (process.stderr as any)?._handle?.setBlocking(true);
+  }
   const { CLIEngine } = await import('eslint');
   const lintRules = fs.readJsonSync(path.join(globalState.projectRootPath, '.eslintrc'));
   const mergedOptions = _.defaults(options || {}, new DefaultOptions());


### PR DESCRIPTION
 process.stdio 在POSIX平台，连接到 pipe 的情况下（如通过child_process运行）是异步执行的，
子进程会在 stdio flush 完成之前退出，导致输出截断。改成 pipe 模式同步执行

https://nodejs.org/dist/latest-v12.x/docs/api/process.html#process_a_note_on_process_i_o