### PR TITLE
feat:add custom options of test

### DIFF
--- a/src/built-in-plugins/command-test/plugin/index.ts
+++ b/src/built-in-plugins/command-test/plugin/index.ts
@@ -36,6 +36,6 @@ pri.commands.registerCommand({
     await pri.project.checkProjectFiles();
 
     const runTestModule = await import('./run-test');
-    runTestModule.runTest();
+    runTestModule.runTest(options);
   },
 });

--- a/src/built-in-plugins/command-test/plugin/interface.ts
+++ b/src/built-in-plugins/command-test/plugin/interface.ts
@@ -1,3 +1,5 @@
 export interface IOpts {
   skipLint?: boolean;
+  notTransform?: boolean;
+  customOptions?: string
 }

--- a/src/built-in-plugins/command-test/plugin/run-test.ts
+++ b/src/built-in-plugins/command-test/plugin/run-test.ts
@@ -4,18 +4,20 @@ import { pri } from '../../../node';
 import { logText } from '../../../utils/log';
 import { findNearestNodemodulesFile } from '../../../utils/npm-finder';
 import { testsPath } from '../../../utils/structor-config';
+import { IOpts } from './interface';
 
-export const runTest = async () => {
+export const runTest = async (options: IOpts) => {
   execSync(
     [
       findNearestNodemodulesFile('/.bin/jest'),
       `--testRegex "${path.join(pri.sourceRoot, testsPath.dir)}/.*\\.tsx?$"`,
       '--moduleFileExtensions ts tsx js jsx',
-      `--transform '${JSON.stringify({
-        [`${path.join(pri.sourceRoot, testsPath.dir)}/.*\\.tsx?$`]: path.join(__dirname, './jest-transformer'),
+      options['notTransform'] ? '' : `--transform '${JSON.stringify({
+        [`${path.join(pri.sourceRoot, testsPath.dir)}/.*\\.tsx?$`]: path.join(__dirname, './jest-transformer')
       })}'`,
       // `--setupFilesAfterEnv '${path.join(__dirname, './jest-setup')}'`,
       '--coverage',
+      options.customOptions || '',
     ]
       .map(each => {
         return each.trim();


### PR DESCRIPTION

1.目前pri单测好像只对tests文件夹下做了transform？导致src下的可能会有一些问题吧
而且命令是写死的--transform，本地jest.config.js文件就不生效了
所以希望加上notTransform配置，可以自己在本地jest.config.js文件配置一些解析方法

2.目前pri单测不支持--watch --u等jest命令，希望可以增加customOptions，让使用方自行配置需要的命令（--watch可以实时监测比较常用，也可以更新jest的快照）