### PR TITLE
feat: add match props to layout component

### DIFF
--- a/src/built-in-plugins/project-analyse-layouts/plugin/index.ts
+++ b/src/built-in-plugins/project-analyse-layouts/plugin/index.ts
@@ -58,7 +58,7 @@ pri.project.onCreateEntry((analyseInfo: IResult, entry) => {
         const ${LAYOUT_ROUTE} = ({ component: Component, ...rest }: any) => {
           return (
             <Route {...rest} render={(matchProps: any) => (
-              <${LAYOUT}>
+              <${LAYOUT} {...matchProps}>
                 <Component {...matchProps} />
               </${LAYOUT}>
             )} />


### PR DESCRIPTION
在布局组件中也会使用到路由对象，但现在是没有把match props加到layout component中。