### PR TITLE
fix: fix typescript compile error when import modules from src/ 

### DIFF
--- a/src/built-in-plugins/command-test/plugin/run-test.ts
+++ b/src/built-in-plugins/command-test/plugin/run-test.ts
@@ -9,10 +9,11 @@ export const runTest = async () => {
   execSync(
     [
       findNearestNodemodulesFile('/.bin/jest'),
+      `--roots "${pri.sourceRoot}"`,
       `--testRegex "${path.join(pri.sourceRoot, testsPath.dir)}/.*\\.tsx?$"`,
       '--moduleFileExtensions ts tsx js jsx',
       `--transform '${JSON.stringify({
-        [`${path.join(pri.sourceRoot, testsPath.dir)}/.*\\.tsx?$`]: path.join(__dirname, './jest-transformer'),
+        [`${pri.sourceRoot}/.*\\.tsx?$`]: path.join(__dirname, './jest-transformer'),
       })}'`,
       // `--setupFilesAfterEnv '${path.join(__dirname, './jest-setup')}'`,
       '--coverage',


### PR DESCRIPTION
Fix typescript compile error when import modules from src/ . For example
```js
import { func } from '../../src/somemodule';

test('some case', () => {
   expect(func()).tobe(false).
});

```