### PR TITLE
feat: support disableDllWhenDev and disableDllWrapWhenDev configuration

### DIFF
--- a/src/built-in-plugins/command-dev/plugin/project-dev.ts
+++ b/src/built-in-plugins/command-dev/plugin/project-dev.ts
@@ -68,6 +68,9 @@ async function debugProject(options?: any) {
   const dashboardClientPort = await portfinder.getPortPromise({ port: freePort + 2 });
 
   const pipeConfig = async (config: webpack.Configuration) => {
+    if (pri.sourceConfig.disableDllWhenDev || pri.sourceConfig.disableDllWrapWhenDev) {
+      return config;
+    }
     const dllHttpPath = urlJoin(
       `${globalState.sourceConfig.useHttps ? 'https' : 'http'}://${pri.sourceConfig.host}:${freePort}`,
       libraryStaticPath,
@@ -99,7 +102,9 @@ async function debugProject(options?: any) {
     return scopeAnalyseInfo;
   });
 
-  await bundleDlls({ dllOutPath, dllFileName, dllMainfestName });
+  if (!pri.sourceConfig.disableDllWhenDev) {
+    await bundleDlls({ dllOutPath, dllFileName, dllMainfestName });
+  }
 
   if (globalState.sourceConfig.useHttps) {
     logInfo('you should set chrome://flags/#allow-insecure-localhost, to trust local certificate.');
@@ -313,6 +318,9 @@ function debugProjectPrepare(dashboardClientPort: number) {
   if (pri.majorCommand === 'dev') {
     pri.build.pipeConfig(config => {
       if (!pri.isDevelopment) {
+        return config;
+      }
+      if (pri.sourceConfig.disableDllWhenDev) {
         return config;
       }
 

--- a/src/utils/define.ts
+++ b/src/utils/define.ts
@@ -354,6 +354,16 @@ export class ProjectConfig {
   public disableDashboard: boolean;
 
   /**
+   * Disable dll in dev mode
+   */
+  public disableDllWhenDev: boolean;
+
+  /**
+   * If disable, pri will not wrap dllScript to entry js in dev mode, your should wrap dllScript to html by yourself
+   */
+  public disableDllWrapWhenDev: boolean;
+
+  /**
    * Publish config for npm publish
    */
   public publishConfig?: IPublishConfig;


### PR DESCRIPTION
DLL配置能提高构建速度，但到了webpack4后，把babel缓存、splitChunks配置好，构建性能已经不错，而DLL维护起来比较麻烦，所以[vue-cli和create-react-app都不再使用DLLPlugin](https://www.cnblogs.com/skychx/p/webpack-dllplugin.html)

并且，qiankun、wujie这种微前端框架都不支持加载用了dll的子应用，本地无法直接调试，没经验时可以花上一天时间才找到绕过办法，比如我的[这篇](https://yuque.antfin.com/yuzheng.tz/wf4813/zuocr5)和十路的[这篇](https://yuque.antfin.com/zhenfeng.wzf/nwe5yx/rnato0)

因此新增了disableDllWhenDev配置，可以允许关闭DLL
同时，目前的WrapContent方式下，入口js和dll.js是串行加载的，我们打算把dll.js由服务端埋到vm里，2个请求可以并行，因此新增了disableDllWrapWhenDev配置，开启后，pri不再用WrapContent把dll.js插入到入口js里
