### PR TITLE
feat: update compilerOptions, target use es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "strictNullChecks": false,
     "jsx": "react",
-    "target": "es5",
+    "target": "es6",
     "rootDir": "./src",
     "experimentalDecorators": true,
     "skipLibCheck": true,


### PR DESCRIPTION
目前compilerOptions的target是es5，可读性差，在业务工程里，有时想看下这版pri的源码，或临时改点东西验证下，会比较麻烦

从 https://node.green/ 里看，8.x的版本就几乎支持了绝大部分es6语法，感觉应该可以把pri编译为es6产物了？