### PR TITLE
feat: add pri.devService.pipeConfig, all modify webpackDevServerConfig

### DIFF
--- a/src/node/dev-service.ts
+++ b/src/node/dev-service.ts
@@ -1,8 +1,17 @@
 import { plugin } from '../utils/plugins';
+import { IDevServerConfigPipe } from '../utils/define';
 
 export const on = (name: string, callback: (data?: any, resolve?: any, reject?: any) => void) => {
   plugin.devServices.socketListeners.push({
     name,
     callback,
   });
+};
+
+/**
+ * It is better not to change the host、port and https here when use DLL
+ * Because of the dllScript'src，is read host、devPort、useHttps from priconfig.json
+ */
+export const pipeConfig = (pipe: IDevServerConfigPipe) => {
+  plugin.devServerConfigPipes.push(pipe);
 };

--- a/src/utils/define.ts
+++ b/src/utils/define.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import { Configuration } from 'webpack';
+import * as WebpackDevServer from 'webpack-dev-server';
 import { Entry } from './create-entry';
 
 export interface PackageJson {
@@ -397,6 +398,10 @@ export interface IPluginModule {
 }
 
 export type IDevDllList = (list: string[]) => string[];
+
+export type IDevServerConfigPipe = (
+  config: WebpackDevServer.Configuration,
+) => WebpackDevServer.Configuration | Promise<WebpackDevServer.Configuration>;
 
 export type IJestConfigPipe = (options: any) => any;
 

--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -20,6 +20,7 @@ import {
   CommandRegister,
   ProjectType,
   IDevDllList,
+  IDevServerConfigPipe,
   IJestConfigPipe,
   IAfterTestRun,
 } from './define';
@@ -93,6 +94,8 @@ export class IPluginConfig {
   public lintFilters: ILintFilter[] = [];
 
   public devDllPipes: IDevDllList[] = [];
+
+  public devServerConfigPipes: IDevServerConfigPipe[] = [];
 
   public jestConfigPipes: IJestConfigPipe[] = [];
 


### PR DESCRIPTION
目前有需要修改webpackDevServerConfig的诉求
useHttps时，虽然是https服务，但由于证书的不安全，chrome有时不会带if-none-match请求头，如这2个资料所说：
[Etags and last-modified over https SSL](https://stackoverflow.com/questions/19101359/etags-and-last-modified-over-https-ssl/19102293)和[Chrome doesn't send "if-none-match" header in HTTPS (but sends it in HTTP)](https://stackoverflow.com/questions/67016037/chrome-doesnt-send-if-none-match-header-in-https-but-sends-it-in-http)

换成http是好的，本地魔改pri，指定devServer的https证书也是好的
umi在9个月前，也做了使用安全证书的改动：https://github.com/xierenyuan/umi/commit/46e325b80be8a0c28107c1e7707f1de44eddfc43#diff-aae796e4377333d833eb8011c216907e55c6f7e7968bfeafb5853667e3d6a840

最好是pri也能借助[mkcert](https://github.com/FiloSottile/mkcert)支持自动生成安全的https证书
目前加个pri.devService.pipeConfig，业务方可以指定证书配置，先支持上