### PR TITLE
feat: support three level packages

### DIFF
--- a/src/utils/global-state.ts
+++ b/src/utils/global-state.ts
@@ -73,8 +73,8 @@ function getPriConfig(rootPath: string) {
 }
 
 function collectPackages(packageRootPath: string, packageDir = PACKAGES_NAME, deep = 0) {
-  // Only support two level packages
-  if (deep >= 2) {
+  // Only support three level packages
+  if (deep >= 3) {
     return;
   }
 


### PR DESCRIPTION
FBI近期在做包结构升级，由于还没做好按需加载的能力，需要有第三层package
之前紫益限制了2层，不知是出于什么考虑，放开到3层后，暂未发现什么负面影响