### PR TITLE
feat: support devProjectConfig, for increase dev project speed

### DIFF
--- a/src/built-in-plugins/command-dev/plugin/project-dev.ts
+++ b/src/built-in-plugins/command-dev/plugin/project-dev.ts
@@ -68,7 +68,7 @@ async function debugProject(options?: any) {
   const dashboardClientPort = await portfinder.getPortPromise({ port: freePort + 2 });
 
   const pipeConfig = async (config: webpack.Configuration) => {
-    if (pri.sourceConfig.disableDllWhenDev || pri.sourceConfig.disableDllWrapWhenDev) {
+    if (pri.sourceConfig.devProjectConfig?.disableDll || pri.sourceConfig.devProjectConfig?.disableDllWrap) {
       return config;
     }
     const dllHttpPath = urlJoin(
@@ -97,12 +97,17 @@ async function debugProject(options?: any) {
   await pri.project.checkProjectFiles();
 
   const analyseInfo = await spinner('Analyse project', async () => {
-    const scopeAnalyseInfo = await analyseProject();
-    await createEntry();
+    let scopeAnalyseInfo;
+    if (!pri.sourceConfig.devProjectConfig?.disableAnalyseProject) {
+      scopeAnalyseInfo = await analyseProject();
+    }
+    if (!pri.sourceConfig.devProjectConfig?.disableCreateEntry) {
+      await createEntry();
+    }
     return scopeAnalyseInfo;
   });
 
-  if (!pri.sourceConfig.disableDllWhenDev) {
+  if (!pri.sourceConfig.devProjectConfig?.disableDll) {
     await bundleDlls({ dllOutPath, dllFileName, dllMainfestName });
   }
 
@@ -320,7 +325,7 @@ function debugProjectPrepare(dashboardClientPort: number) {
       if (!pri.isDevelopment) {
         return config;
       }
-      if (pri.sourceConfig.disableDllWhenDev) {
+      if (pri.sourceConfig.devProjectConfig?.disableDll) {
         return config;
       }
 

--- a/src/utils/define.ts
+++ b/src/utils/define.ts
@@ -355,14 +355,34 @@ export class ProjectConfig {
   public disableDashboard: boolean;
 
   /**
-   * Disable dll in dev mode
+   * Dev config for project
    */
-  public disableDllWhenDev: boolean;
+  public devProjectConfig?: {
+    /**
+     * Disable dll
+     */
+    disableDll: boolean;
 
-  /**
-   * If disable, pri will not wrap dllScript to entry js in dev mode, your should wrap dllScript to html by yourself
-   */
-  public disableDllWrapWhenDev: boolean;
+    /**
+     * If disable, pri will not wrap dllScript to entry js, your should wrap dllScript to html by yourself
+     */
+    disableDllWrap: boolean;
+
+    /**
+     * Disable analyse Project
+     */
+    disableAnalyseProject: boolean;
+
+    /**
+     * If disable, pri will not create entry js, you should handle route and ReactDom.render by yourself
+     */
+    disableCreateEntry: boolean;
+
+    /**
+     * The pri plugin that need be disabled,
+     */
+    disablePluginNames: string[];
+  };
 
   /**
    * Publish config for npm publish
@@ -397,7 +417,7 @@ export interface IEnsureProjectFilesQueue {
 export type ILintFilter = (filePath?: string) => boolean;
 
 export interface IPluginModule {
-  getConfig?: () => {
+  getConfig: () => {
     // Plugin name
     name: string;
     // Dependent plugin names

--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -25,7 +25,7 @@ import {
   IAfterTestRun,
 } from './define';
 import { getBabelOptions } from './babel-options';
-import { tempPath, srcPath } from '../node';
+import { tempPath, srcPath, pri } from '../node';
 import * as pluginClientSsr from '../built-in-plugins/client-ssr';
 import * as pluginCommandAnalyse from '../built-in-plugins/command-analyse';
 import * as pluginCommandBuild from '../built-in-plugins/command-build';
@@ -340,8 +340,15 @@ function addPluginFromEntry(entryPath: string) {
     logFatal('Plugin must impletement getPlugin method!');
   }
 
-  if (!instance.getConfig().name) {
+  const name = instance.getConfig().name;
+  if (!name) {
     logFatal('Plugin must have name!');
+  }
+
+  if (pri.majorCommand === 'dev' && pri.sourceConfig.type === 'project') {
+    if (pri.sourceConfig.devProjectConfig?.disablePluginNames?.includes(name)) {
+      return;
+    }
   }
 
   loadedPlugins.add(instance);


### PR DESCRIPTION
FBI目前pri dev时，在启动pri阶段耗时十多秒，主要是：
1、总共引入了49个pri插件，插件的加载耗时约5秒
2、analyseProject，会遍历读取所有文件，共6000+文件，耗时9秒左右

可以优化的点：
1、有些插件是FBI不需要的，但被一些插件集合如@ali/pri-plugin-dt、pri-plugin-hornet引入了，然后有些插件不是for dev的，但耗时比较多，比如publish、cr
2、analyseProject得到的analyseInfo，是为了后面的dashboardServer，FBI设置了disableDashboard，其实不需要analyseProject

因此新增了devProjectConfig配置，可以禁用这些特性，FBI启动可以降低12秒+的耗时
然后FBI目前计划拆分业务包，可以单独启动业务包package，entry的逻辑自行实现，不用pri去create entry了，因此在devProjectConfig里也新增了个disableCreateEntry
